### PR TITLE
Remove double newlines

### DIFF
--- a/Swat/SwatAbstractMenu.php
+++ b/Swat/SwatAbstractMenu.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Abstract base class for menus in Swat
  *

--- a/Swat/SwatAbstractOverlay.php
+++ b/Swat/SwatAbstractOverlay.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Abstract javascript overlay widget.
  *

--- a/Swat/SwatAccordion.php
+++ b/Swat/SwatAccordion.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Accordion widget containing {@link SwatNoteBookPage} pages.
  *

--- a/Swat/SwatActionItem.php
+++ b/Swat/SwatActionItem.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A single entry in a {@link SwatActions} widget
  *

--- a/Swat/SwatActionItemDivider.php
+++ b/Swat/SwatActionItemDivider.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A divider entry in a SwatActions widget
  *

--- a/Swat/SwatActions.php
+++ b/Swat/SwatActions.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Actions widget
  *

--- a/Swat/SwatAutoloader.php
+++ b/Swat/SwatAutoloader.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Automatically requires PHP files for undefined classes
  *

--- a/Swat/SwatAutoloaderRule.php
+++ b/Swat/SwatAutoloaderRule.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A class autoloader rule
  *

--- a/Swat/SwatBooleanCellRenderer.php
+++ b/Swat/SwatBooleanCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A cell renderer for a boolean value
  *

--- a/Swat/SwatButton.php
+++ b/Swat/SwatButton.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A button widget
  *

--- a/Swat/SwatByteCellRenderer.php
+++ b/Swat/SwatByteCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A cell renderer for rendering base-2 units of information
  *

--- a/Swat/SwatCalendar.php
+++ b/Swat/SwatCalendar.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Pop-up calendar widget
  *

--- a/Swat/SwatCascadeFlydown.php
+++ b/Swat/SwatCascadeFlydown.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A cascading flydown (aka combo-box) selection widget
  *

--- a/Swat/SwatCellRenderer.php
+++ b/Swat/SwatCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Object for rendering a single cell
  *

--- a/Swat/SwatCellRendererContainer.php
+++ b/Swat/SwatCellRendererContainer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Abstract base class for objects which contain cell renderers.
  *

--- a/Swat/SwatCellRendererMapping.php
+++ b/Swat/SwatCellRendererMapping.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A mapping of a data field to property of a cell renderer.
  *

--- a/Swat/SwatCellRendererSet.php
+++ b/Swat/SwatCellRendererSet.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A collection of cell renderers with associated datafield-property mappings
  *

--- a/Swat/SwatChangeOrder.php
+++ b/Swat/SwatChangeOrder.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An element ordering widget
  *

--- a/Swat/SwatCheckAll.php
+++ b/Swat/SwatCheckAll.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A "check all" JavaScript powered checkbox
  *

--- a/Swat/SwatCheckbox.php
+++ b/Swat/SwatCheckbox.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A checkbox entry widget
  *

--- a/Swat/SwatCheckboxCellRenderer.php
+++ b/Swat/SwatCheckboxCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A view selector cell renderer displayed as a checkbox
  *

--- a/Swat/SwatCheckboxEntryList.php
+++ b/Swat/SwatCheckboxEntryList.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A checkbox list widget with entries per option
  *

--- a/Swat/SwatCheckboxList.php
+++ b/Swat/SwatCheckboxList.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A checkbox list widget
  *

--- a/Swat/SwatCheckboxTree.php
+++ b/Swat/SwatCheckboxTree.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A checkbox array widget formatted into a tree
  *

--- a/Swat/SwatColorEntry.php
+++ b/Swat/SwatColorEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A color selector widget with palette
  *

--- a/Swat/SwatCommentHtmlHeadEntry.php
+++ b/Swat/SwatCommentHtmlHeadEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Stores and outputs an HTML head entry for an XML comment
  *

--- a/Swat/SwatConfirmEmailEntry.php
+++ b/Swat/SwatConfirmEmailEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An email address confirmation entry widget
  *

--- a/Swat/SwatConfirmPasswordEntry.php
+++ b/Swat/SwatConfirmPasswordEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A password confirmation entry widget
  *

--- a/Swat/SwatConfirmationButton.php
+++ b/Swat/SwatConfirmationButton.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A button widget with a javascript confirmation dialog
  *

--- a/Swat/SwatContainer.php
+++ b/Swat/SwatContainer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Swat container widget
  *

--- a/Swat/SwatContentBlock.php
+++ b/Swat/SwatContentBlock.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A block of content in the widget tree
  *

--- a/Swat/SwatControl.php
+++ b/Swat/SwatControl.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Abstract base class for control widgets (non-container)
  *

--- a/Swat/SwatDataTreeNode.php
+++ b/Swat/SwatDataTreeNode.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A tree node containing a value and a title
  *

--- a/Swat/SwatDate.php
+++ b/Swat/SwatDate.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Date class and PEAR-compatibility layer
  *

--- a/Swat/SwatDateCellRenderer.php
+++ b/Swat/SwatDateCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A text renderer.
  *

--- a/Swat/SwatDateEntry.php
+++ b/Swat/SwatDateEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A date entry widget
  *

--- a/Swat/SwatDetailsStore.php
+++ b/Swat/SwatDetailsStore.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A data structure that can be used with the SwatDetailsView
  *

--- a/Swat/SwatDetailsView.php
+++ b/Swat/SwatDetailsView.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A widget to display field-value pairs
  *

--- a/Swat/SwatDetailsViewField.php
+++ b/Swat/SwatDetailsViewField.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A visible field in a SwatDetailsView
  *

--- a/Swat/SwatDetailsViewVerticalField.php
+++ b/Swat/SwatDetailsViewVerticalField.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A visible field in a SwatDetailsView that has its label displayed above
  * its content

--- a/Swat/SwatDisclosure.php
+++ b/Swat/SwatDisclosure.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A container to show and hide child widgets
  *

--- a/Swat/SwatDisplayableContainer.php
+++ b/Swat/SwatDisplayableContainer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Base class for containers that display an XHTML element
  *

--- a/Swat/SwatEmailEntry.php
+++ b/Swat/SwatEmailEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An email entry widget
  *

--- a/Swat/SwatEntry.php
+++ b/Swat/SwatEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A single line text entry widget
  *
@@ -124,7 +123,6 @@ class SwatEntry extends SwatInputControl implements SwatState
 	 * @var boolean
 	 */
 	public $auto_trim = true;
-
 
 	// }}}
 	// {{{ public function display()

--- a/Swat/SwatError.php
+++ b/Swat/SwatError.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An error in Swat
  *

--- a/Swat/SwatErrorDisplayer.php
+++ b/Swat/SwatErrorDisplayer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Abstract base class for displaying SwatError objects
  *

--- a/Swat/SwatErrorLogger.php
+++ b/Swat/SwatErrorLogger.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Abstract base class for logging SwatError objects
  *

--- a/Swat/SwatExceptionDisplayer.php
+++ b/Swat/SwatExceptionDisplayer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Abstract base class for displaying SwatException objects
  *

--- a/Swat/SwatExceptionLogger.php
+++ b/Swat/SwatExceptionLogger.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Abstract base class for logging SwatException objects
  *

--- a/Swat/SwatExpandableCheckboxTree.php
+++ b/Swat/SwatExpandableCheckboxTree.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A checkbox array widget formatted into a tree where each branch can
  * be expanded

--- a/Swat/SwatFieldset.php
+++ b/Swat/SwatFieldset.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Fieldset tag container
  *

--- a/Swat/SwatFileEntry.php
+++ b/Swat/SwatFileEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A file upload widget
  *

--- a/Swat/SwatFloatEntry.php
+++ b/Swat/SwatFloatEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A float entry widget
  *

--- a/Swat/SwatFlydown.php
+++ b/Swat/SwatFlydown.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A flydown (aka combo-box) selection widget
  *

--- a/Swat/SwatFlydownBlankOption.php
+++ b/Swat/SwatFlydownBlankOption.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A class representing a blank option in a flydown
  *

--- a/Swat/SwatFlydownDivider.php
+++ b/Swat/SwatFlydownDivider.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A class representing a divider in a flydown
  *

--- a/Swat/SwatFooterFormField.php
+++ b/Swat/SwatFooterFormField.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A container to use around control widgets in a form
  *

--- a/Swat/SwatForm.php
+++ b/Swat/SwatForm.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A form widget which can contain other widgets
  *

--- a/Swat/SwatFormField.php
+++ b/Swat/SwatFormField.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A container to use around control widgets in a form
  *

--- a/Swat/SwatFrame.php
+++ b/Swat/SwatFrame.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A container with a decorative frame and optional title
  *

--- a/Swat/SwatFrameDisclosure.php
+++ b/Swat/SwatFrameDisclosure.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A frame-like container to show and hide child widgets
  *

--- a/Swat/SwatGroupedFlydown.php
+++ b/Swat/SwatGroupedFlydown.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A tree flydown input control that displays flydown options in optgroups
  *

--- a/Swat/SwatGroupedMenu.php
+++ b/Swat/SwatGroupedMenu.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A menu control where menu items are grouped together
  *

--- a/Swat/SwatGroupingFormField.php
+++ b/Swat/SwatGroupingFormField.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A grouping form field
  *

--- a/Swat/SwatHeaderFormField.php
+++ b/Swat/SwatHeaderFormField.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A container to use around control widgets in a form
  *

--- a/Swat/SwatHtmlHeadEntry.php
+++ b/Swat/SwatHtmlHeadEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Stores and outputs an HTML head entry
  *

--- a/Swat/SwatHtmlHeadEntrySet.php
+++ b/Swat/SwatHtmlHeadEntrySet.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A collection of HTML head entries
  *

--- a/Swat/SwatHtmlHeadEntrySetDisplayer.php
+++ b/Swat/SwatHtmlHeadEntrySetDisplayer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Displays HTML head entries
  *

--- a/Swat/SwatHtmlTag.php
+++ b/Swat/SwatHtmlTag.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Stores and outputs an HTML tag
  *

--- a/Swat/SwatImageButton.php
+++ b/Swat/SwatImageButton.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An image button widget
  *

--- a/Swat/SwatImageCellRenderer.php
+++ b/Swat/SwatImageCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An image renderer
  *

--- a/Swat/SwatImageCropper.php
+++ b/Swat/SwatImageCropper.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An image cropping widget
  *

--- a/Swat/SwatImageDisplay.php
+++ b/Swat/SwatImageDisplay.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Image display control
  *

--- a/Swat/SwatImageLinkCellRenderer.php
+++ b/Swat/SwatImageLinkCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A renderer that displays a hyperlinked image
  *

--- a/Swat/SwatImagePreviewDisplay.php
+++ b/Swat/SwatImagePreviewDisplay.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Image preview display control
  *

--- a/Swat/SwatInlineJavaScriptHtmlHeadEntry.php
+++ b/Swat/SwatInlineJavaScriptHtmlHeadEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * @package   Swat
  * @copyright 2012-2016 silverorange

--- a/Swat/SwatInputCell.php
+++ b/Swat/SwatInputCell.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A cell container that contains a widget and is bound to a
  * {@link SwatTableViewInputRow} object

--- a/Swat/SwatInputControl.php
+++ b/Swat/SwatInputControl.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Base class for controls that accept user input on forms.
  *

--- a/Swat/SwatIntegerEntry.php
+++ b/Swat/SwatIntegerEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An integer entry widget
  *

--- a/Swat/SwatJavaScriptHtmlHeadEntry.php
+++ b/Swat/SwatJavaScriptHtmlHeadEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Stores and outputs an HTML head entry for a JavaScript include
  *

--- a/Swat/SwatLessStyleSheetHtmlHeadEntry.php
+++ b/Swat/SwatLessStyleSheetHtmlHeadEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Stores and outputs an HTML head entry for a LESS stylesheet include
  *

--- a/Swat/SwatLinkCellRenderer.php
+++ b/Swat/SwatLinkCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A link cell renderer
  *

--- a/Swat/SwatLinkHtmlHeadEntry.php
+++ b/Swat/SwatLinkHtmlHeadEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Stores and outputs an HTML head entry for an XHTML link element
  *

--- a/Swat/SwatListEntry.php
+++ b/Swat/SwatListEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An input control for entering a delimited list of data
  *

--- a/Swat/SwatMenu.php
+++ b/Swat/SwatMenu.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A basic menu control
  *

--- a/Swat/SwatMenuBar.php
+++ b/Swat/SwatMenuBar.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A menu bar control
  *

--- a/Swat/SwatMenuGroup.php
+++ b/Swat/SwatMenuGroup.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A group of menu items
  *

--- a/Swat/SwatMenuItem.php
+++ b/Swat/SwatMenuItem.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An item in a menu
  *

--- a/Swat/SwatMessage.php
+++ b/Swat/SwatMessage.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A data class to store a message
  *

--- a/Swat/SwatMessageDisplay.php
+++ b/Swat/SwatMessageDisplay.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A control to display {@link SwatMessage} objects
  *

--- a/Swat/SwatMoneyCellRenderer.php
+++ b/Swat/SwatMoneyCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A currency cell renderer
  *

--- a/Swat/SwatMoneyEntry.php
+++ b/Swat/SwatMoneyEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A money entry widget
  *

--- a/Swat/SwatNavBar.php
+++ b/Swat/SwatNavBar.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Visible navigation tool (breadcrumb trail)
  *

--- a/Swat/SwatNavBarEntry.php
+++ b/Swat/SwatNavBarEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Entry for the navbar navigation tool
  *

--- a/Swat/SwatNoteBook.php
+++ b/Swat/SwatNoteBook.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Notebook widget for containing {@link SwatNoteBookPage} pages
  *

--- a/Swat/SwatNoteBookPage.php
+++ b/Swat/SwatNoteBookPage.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A page in a {@link SwatNoteBook}
  *

--- a/Swat/SwatNullTextCellRenderer.php
+++ b/Swat/SwatNullTextCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A cell renderer that displays a message if it is asked to display
  * null text

--- a/Swat/SwatNumber.php
+++ b/Swat/SwatNumber.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Number tools
  *

--- a/Swat/SwatNumericCellRenderer.php
+++ b/Swat/SwatNumericCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A numeric cell renderer
  *

--- a/Swat/SwatNumericEntry.php
+++ b/Swat/SwatNumericEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Base class for numeric entry widgets
  *

--- a/Swat/SwatObject.php
+++ b/Swat/SwatObject.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * The base object type
  *

--- a/Swat/SwatOption.php
+++ b/Swat/SwatOption.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A simple class for storing options used in various Swat controls
  *

--- a/Swat/SwatOptionControl.php
+++ b/Swat/SwatOptionControl.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A base class for controls using a set of options
  *

--- a/Swat/SwatPagination.php
+++ b/Swat/SwatPagination.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A widget to allow navigation between paged data
  *

--- a/Swat/SwatPasswordEntry.php
+++ b/Swat/SwatPasswordEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A password entry widget
  *

--- a/Swat/SwatPercentageCellRenderer.php
+++ b/Swat/SwatPercentageCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A percentage cell renderer
  *

--- a/Swat/SwatPercentageEntry.php
+++ b/Swat/SwatPercentageEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A percentage entry widget
  *

--- a/Swat/SwatPhoneEntry.php
+++ b/Swat/SwatPhoneEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An phone number entry widget
  *

--- a/Swat/SwatProgressBar.php
+++ b/Swat/SwatProgressBar.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Progress bar
  *

--- a/Swat/SwatRadioButtonCellRenderer.php
+++ b/Swat/SwatRadioButtonCellRenderer.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * A view selector cell renderer displayed as a radio button
  *

--- a/Swat/SwatRadioList.php
+++ b/Swat/SwatRadioList.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A radio list selection widget
  *

--- a/Swat/SwatRadioNoteBook.php
+++ b/Swat/SwatRadioNoteBook.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Notebook widget for containing {@link SwatNoteBookPage} pages
  *

--- a/Swat/SwatRadioTable.php
+++ b/Swat/SwatRadioTable.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Special radio-list that can display multi-line list items using a
  * tabular format

--- a/Swat/SwatRating.php
+++ b/Swat/SwatRating.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A control for recording a rating out of a variable number of values
  *

--- a/Swat/SwatRatingCellRenderer.php
+++ b/Swat/SwatRatingCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A rating cell renderer
  *

--- a/Swat/SwatReCaptcha.php
+++ b/Swat/SwatReCaptcha.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A widget used to display and validate reCAPTCHA's
  *

--- a/Swat/SwatRemoveInputCell.php
+++ b/Swat/SwatRemoveInputCell.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An input cell containing a "remove row" link
  *

--- a/Swat/SwatReplicableContainer.php
+++ b/Swat/SwatReplicableContainer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A container that replicates itself and its children
  *

--- a/Swat/SwatReplicableDisclosure.php
+++ b/Swat/SwatReplicableDisclosure.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A disclosure that replicates its children
  *

--- a/Swat/SwatReplicableFieldset.php
+++ b/Swat/SwatReplicableFieldset.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A fieldset container that replicates itself and its children
  *

--- a/Swat/SwatReplicableFormField.php
+++ b/Swat/SwatReplicableFormField.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A form field container that replicates its children
  *

--- a/Swat/SwatReplicableFrame.php
+++ b/Swat/SwatReplicableFrame.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A frame that replicates its children
  *

--- a/Swat/SwatReplicableNoteBookChild.php
+++ b/Swat/SwatReplicableNoteBookChild.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A replicable container that replicates {@link SwatNoteBookChild} objects
  *

--- a/Swat/SwatReplicableNoteBookPage.php
+++ b/Swat/SwatReplicableNoteBookPage.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A container that replicates itself and its children as pages of a notebook
  *

--- a/Swat/SwatReplicatorFieldset.php
+++ b/Swat/SwatReplicatorFieldset.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A fieldset container that replicates itself and its children
  *

--- a/Swat/SwatReplicatorFormField.php
+++ b/Swat/SwatReplicatorFormField.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A form field container that replicates its children
  *

--- a/Swat/SwatSearchEntry.php
+++ b/Swat/SwatSearchEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A single line search entry widget
  *

--- a/Swat/SwatSelectList.php
+++ b/Swat/SwatSelectList.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * List of selectable options
  *

--- a/Swat/SwatSimpleColorEntry.php
+++ b/Swat/SwatSimpleColorEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Simple color selector widget.
  *

--- a/Swat/SwatString.php
+++ b/Swat/SwatString.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * String Tools
  *

--- a/Swat/SwatStyleSheetHtmlHeadEntry.php
+++ b/Swat/SwatStyleSheetHtmlHeadEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Stores and outputs an HTML head entry for a stylesheet include
  *

--- a/Swat/SwatTableModel.php
+++ b/Swat/SwatTableModel.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * The data model for a SwatTableView
  *

--- a/Swat/SwatTableStore.php
+++ b/Swat/SwatTableStore.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A data structure that can be used with the SwatTableView
  *

--- a/Swat/SwatTableView.php
+++ b/Swat/SwatTableView.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A widget to display data in a tabular form
  *

--- a/Swat/SwatTableViewCheckAllRow.php
+++ b/Swat/SwatTableViewCheckAllRow.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A an extra row containing a check-all widget
  *

--- a/Swat/SwatTableViewCheckboxColumn.php
+++ b/Swat/SwatTableViewCheckboxColumn.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A special table-view column designed to contain a checkbox cell renderer
  *

--- a/Swat/SwatTableViewColumn.php
+++ b/Swat/SwatTableViewColumn.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A visible column in a SwatTableView
  *

--- a/Swat/SwatTableViewGroup.php
+++ b/Swat/SwatTableViewGroup.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A visible grouping of rows in a table view
  *

--- a/Swat/SwatTableViewInputRow.php
+++ b/Swat/SwatTableViewInputRow.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A table-view row that allows the user to enter data
  *

--- a/Swat/SwatTableViewOrderableColumn.php
+++ b/Swat/SwatTableViewOrderableColumn.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An orderable table view column.
  *

--- a/Swat/SwatTableViewRow.php
+++ b/Swat/SwatTableViewRow.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Base class for a extra row displayed at the bottom of a table view
  *

--- a/Swat/SwatTableViewSpanningColumn.php
+++ b/Swat/SwatTableViewSpanningColumn.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * This is a table view column that gets its own row.
  *

--- a/Swat/SwatTableViewWidgetRow.php
+++ b/Swat/SwatTableViewWidgetRow.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A table view row with an optional contained widget
  *

--- a/Swat/SwatTextCellRenderer.php
+++ b/Swat/SwatTextCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A text cell renderer
  *

--- a/Swat/SwatTextarea.php
+++ b/Swat/SwatTextarea.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A multi-line text entry widget
  *

--- a/Swat/SwatTextareaEditor.php
+++ b/Swat/SwatTextareaEditor.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A what-you-see-is-what-you-get (WYSIWYG) XHTML textarea editor widget
  *

--- a/Swat/SwatTile.php
+++ b/Swat/SwatTile.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A tile in a {@link SwatTileView}
  *

--- a/Swat/SwatTileView.php
+++ b/Swat/SwatTileView.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A tile view widget for containing a {@link SwatTile} tile
  *

--- a/Swat/SwatTileViewGroup.php
+++ b/Swat/SwatTileViewGroup.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A visible grouping of tiles in a tile view
  *

--- a/Swat/SwatTimeEntry.php
+++ b/Swat/SwatTimeEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A time entry widget
  *

--- a/Swat/SwatTimeZoneEntry.php
+++ b/Swat/SwatTimeZoneEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A time zone selection widget
  *

--- a/Swat/SwatToolLink.php
+++ b/Swat/SwatToolLink.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A a tool link in the widget tree
  *

--- a/Swat/SwatToolbar.php
+++ b/Swat/SwatToolbar.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A toolbar container for a group of related {@link SwatToolLink} objects
  *

--- a/Swat/SwatTreeFlydown.php
+++ b/Swat/SwatTreeFlydown.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A flydown (aka combo-box) selection widget that displays a tree of flydown
  * options

--- a/Swat/SwatTreeFlydownNode.php
+++ b/Swat/SwatTreeFlydownNode.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A tree node for a flydown
  *

--- a/Swat/SwatTreeNode.php
+++ b/Swat/SwatTreeNode.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A simple class for building a tree structure
  *

--- a/Swat/SwatUI.php
+++ b/Swat/SwatUI.php
@@ -2,8 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
-
 /**
  * Generates a Swat widget tree from an XML UI file
  *

--- a/Swat/SwatUIObject.php
+++ b/Swat/SwatUIObject.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A base class for Swat user-interface elements
  *

--- a/Swat/SwatUriEntry.php
+++ b/Swat/SwatUriEntry.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A URI entry widget
  *

--- a/Swat/SwatView.php
+++ b/Swat/SwatView.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An abstract class from which to derive recordset views
  *

--- a/Swat/SwatViewSelection.php
+++ b/Swat/SwatViewSelection.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A selection on a view
  *

--- a/Swat/SwatWidget.php
+++ b/Swat/SwatWidget.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Base class for all widgets
  *

--- a/Swat/SwatWidgetCellRenderer.php
+++ b/Swat/SwatWidgetCellRenderer.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  *
  * @package   Swat

--- a/Swat/SwatXHTMLTextarea.php
+++ b/Swat/SwatXHTMLTextarea.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A text area that validates its content as an XHTML fragment against the
  * XHTML Strict DTD

--- a/Swat/SwatYUI.php
+++ b/Swat/SwatYUI.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Object for building Swat HTML head entry dependencies for Yahoo UI Library
  * components

--- a/Swat/SwatYUIComponent.php
+++ b/Swat/SwatYUIComponent.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A component in the Yahoo UI Library
  *

--- a/Swat/SwatYesNoFlydown.php
+++ b/Swat/SwatYesNoFlydown.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A flydown (aka combo-box) selection widget for a Yes/No option.
  *

--- a/Swat/SwatYesNoRadioList.php
+++ b/Swat/SwatYesNoRadioList.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A radio list selection widget for a Yes/No option.
  *

--- a/Swat/exceptions/SwatClassNotFoundException.php
+++ b/Swat/exceptions/SwatClassNotFoundException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when a class is not found
  *

--- a/Swat/exceptions/SwatCrossSiteRequestForgeryException.php
+++ b/Swat/exceptions/SwatCrossSiteRequestForgeryException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown by {@link SwatForm} when a possible cross-site request forgery is
  * detected

--- a/Swat/exceptions/SwatDoesNotImplementException.php
+++ b/Swat/exceptions/SwatDoesNotImplementException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when an object does not implement a required interface
  *

--- a/Swat/exceptions/SwatDuplicateIdException.php
+++ b/Swat/exceptions/SwatDuplicateIdException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when the ids of two objects collide
  *

--- a/Swat/exceptions/SwatException.php
+++ b/Swat/exceptions/SwatException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An exception in Swat
  *

--- a/Swat/exceptions/SwatFileNotFoundException.php
+++ b/Swat/exceptions/SwatFileNotFoundException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when a file is not found
  *

--- a/Swat/exceptions/SwatInvalidCallbackException.php
+++ b/Swat/exceptions/SwatInvalidCallbackException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when a users tries to set a callback to a value that is not a
  * callback

--- a/Swat/exceptions/SwatInvalidCharacterEncodingException.php
+++ b/Swat/exceptions/SwatInvalidCharacterEncodingException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when character data is in an unrecognized or invalid character
  * encoding

--- a/Swat/exceptions/SwatInvalidClassException.php
+++ b/Swat/exceptions/SwatInvalidClassException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when an object is of the wrong class
  *

--- a/Swat/exceptions/SwatInvalidConstantExpressionException.php
+++ b/Swat/exceptions/SwatInvalidConstantExpressionException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when an invalid constant expression is used
  *

--- a/Swat/exceptions/SwatInvalidPropertyException.php
+++ b/Swat/exceptions/SwatInvalidPropertyException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when an invalid property of an object is accessed
  *

--- a/Swat/exceptions/SwatInvalidPropertyTypeException.php
+++ b/Swat/exceptions/SwatInvalidPropertyTypeException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when an invalid property type is used.
  *

--- a/Swat/exceptions/SwatInvalidSerializedDataException.php
+++ b/Swat/exceptions/SwatInvalidSerializedDataException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when a serialized value is poisioned (does not match salted value)
  *

--- a/Swat/exceptions/SwatInvalidSwatMLException.php
+++ b/Swat/exceptions/SwatInvalidSwatMLException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * An exception in Swat
  *

--- a/Swat/exceptions/SwatInvalidTypeException.php
+++ b/Swat/exceptions/SwatInvalidTypeException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when a value is of the wrong type
  *

--- a/Swat/exceptions/SwatObjectNotFoundException.php
+++ b/Swat/exceptions/SwatObjectNotFoundException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when a object is not found
  *

--- a/Swat/exceptions/SwatUndefinedConstantException.php
+++ b/Swat/exceptions/SwatUndefinedConstantException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when a constant is used that is not defined
  *

--- a/Swat/exceptions/SwatUndefinedMessageTypeException.php
+++ b/Swat/exceptions/SwatUndefinedMessageTypeException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when a message type is used that is not defined
  *

--- a/Swat/exceptions/SwatUndefinedStockTypeException.php
+++ b/Swat/exceptions/SwatUndefinedStockTypeException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when a stock type is used that is not defined
  *

--- a/Swat/exceptions/SwatWidgetNotFoundException.php
+++ b/Swat/exceptions/SwatWidgetNotFoundException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Thrown when a widget is not found
  *

--- a/SwatDB/SwatDB.php
+++ b/SwatDB/SwatDB.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Database helper class
  *

--- a/SwatDB/SwatDBClassMap.php
+++ b/SwatDB/SwatDBClassMap.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * Maps class names to overridden class names
  *

--- a/SwatDB/SwatDBDataObject.php
+++ b/SwatDB/SwatDBDataObject.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * All public properties correspond to database fields
  *

--- a/SwatDB/SwatDBDefaultRecordsetWrapper.php
+++ b/SwatDB/SwatDBDefaultRecordsetWrapper.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * MDB2 Recordset Wrapper
  *

--- a/SwatDB/SwatDBField.php
+++ b/SwatDB/SwatDBField.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Database field
  *

--- a/SwatDB/SwatDBMarshallable.php
+++ b/SwatDB/SwatDBMarshallable.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Interface for marshalling and unmarshalling data-objects
  *

--- a/SwatDB/SwatDBRange.php
+++ b/SwatDB/SwatDBRange.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * A single object to represent a database query range
  *

--- a/SwatDB/SwatDBReadaheadIterator.php
+++ b/SwatDB/SwatDBReadaheadIterator.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Readahead iterator
  *

--- a/SwatDB/SwatDBRecordsetWrapper.php
+++ b/SwatDB/SwatDBRecordsetWrapper.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * MDB2 recordset wrapper
  *

--- a/SwatDB/SwatDBTransaction.php
+++ b/SwatDB/SwatDBTransaction.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A database transaction that is safe to use with database drivers that do
  * not support nested transactions

--- a/SwatDB/exceptions/SwatDBException.php
+++ b/SwatDB/exceptions/SwatDBException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * A SwatDB Exception.
  *

--- a/SwatDB/exceptions/SwatDBMarshallException.php
+++ b/SwatDB/exceptions/SwatDBMarshallException.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
 /**

--- a/SwatDB/exceptions/SwatDBNoDatabaseException.php
+++ b/SwatDB/exceptions/SwatDBNoDatabaseException.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-
 /**
  * Exception thrown when no database is available
  *

--- a/SwatI18N/SwatI18NCurrencyFormat.php
+++ b/SwatI18N/SwatI18NCurrencyFormat.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * Information for formatting currency values
  *

--- a/SwatI18N/SwatI18NLocale.php
+++ b/SwatI18N/SwatI18NLocale.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * A locale object
  *

--- a/SwatI18N/SwatI18NNumberFormat.php
+++ b/SwatI18N/SwatI18NNumberFormat.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * Information for formatting numeric values
  *


### PR DESCRIPTION
Arcane magic:

```sh
find . -type f -name '*.php' -exec ex -s -c '%s/\n\{3,}/\r\r/g' -cwq {} \;
```